### PR TITLE
Use status returned explicitly to determine success

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,4 +20,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.13.5
+   2.1.4

--- a/bin/github-grep
+++ b/bin/github-grep
@@ -63,16 +63,16 @@ def page(q, type, page, per_page)
   # remove --fail and add -v to see response headers
   # NOTE: github returns a 403 with a Retry-After: 60 on page 3+ ... talking with support atm but might have to handle it
   url = "https://api.github.com/search/#{type}?per_page=#{per_page}&page=#{page}&q=#{CGI.escape(q)}"
-  command = ["curl", "-v", "-H", "Authorization: token #{github_token}", "-H", "Accept: application/vnd.github.v3.text-match+json", url]
+  command = ["curl", "-v", "-f", "-H", "Authorization: token #{github_token}", "-H", "Accept: application/vnd.github.v3.text-match+json", url]
 
-  out, err, _ = Open3.capture3(*command)
+  out, err, status = Open3.capture3(*command)
   if retry_after = err[/Retry-After: (\d+)/, 1] # 403 Abuse rate limit
     warn "Sleeping #{retry_after} to avoid abuse rate-limit"
     sleep Integer(retry_after)
-    out, err, _ = Open3.capture3(*command)
+    out, err, status = Open3.capture3(*command)
   end
 
-  raise "ERROR Request failed\n#{url}\n#{err}\n#{out}" unless err.downcase.include?("< status: 200 ok")
+  raise "ERROR Request failed\n#{url}\n#{err}\n#{out}" unless status.success?
 
   JSON.load(out)
 end


### PR DESCRIPTION
Make curl fail and use the status captured to determine success.